### PR TITLE
Change is_donor_only for site supervisor. Fixes #159.

### DIFF
--- a/onadata/apps/fieldsight/rolemixins.py
+++ b/onadata/apps/fieldsight/rolemixins.py
@@ -179,7 +179,7 @@ class ReadonlySiteLevelRoleMixin(LoginRequiredMixin):
 
         user_role = request.roles.filter(site_id = site_id, group__name__in=["Reviewer","Site Supervisor"])
         if user_role:
-            return super(ReadonlySiteLevelRoleMixin, self).dispatch(request, is_donor_only=True, *args, **kwargs)
+            return super(ReadonlySiteLevelRoleMixin, self).dispatch(request, is_donor_only=False, *args, **kwargs)
 
         user_role_asdonor = request.roles.filter( project_id = project.id, group__name="Project Donor")
         if user_role_asdonor:


### PR DESCRIPTION
Set `is_donor_only` as True in **rolemixins.py** if user is **Site Reviewer or Site supervisor**. This solves the issue of redirecting to the **lite site dashboard** whenever the site supervisor clicks the `Site Name` link in breadcrumb in **Site responses list(view data)** of site and avoids permission denied page.