### PR TITLE
Remove project type information from userrole api

### DIFF
--- a/onadata/apps/userrole/serializers/UserRoleSerializer.py
+++ b/onadata/apps/userrole/serializers/UserRoleSerializer.py
@@ -52,8 +52,7 @@ class MySiteRolesSerializer(serializers.ModelSerializer):
         project = obj.project
 
         return {'name': project.name, 'id': project.id, 'description': project.public_desc,
-                                         'address':project.address, 'type_id':project.type.id,
-                                         'type_label':project.type.name,'phone':project.phone, 'organization_name':project.organization.name,
+                                         'address':project.address, 'phone':project.phone, 'organization_name':project.organization.name,
                                          'organization_url':project.organization.logo.url,
                                          'lat': repr(project.latitude), 'lon': repr(project.longitude), 'cluster_sites':project.cluster_sites, 'site_meta_attributes':project.site_meta_attributes}
 


### PR DESCRIPTION
After using project sector type, there is no need of project types in newly created projects. The newly created project won't contain any types. Empty project type will cause an error while downloading the projects in mobile app. Hence, removing the project type information from the api would solve this problem. Also, project type information has not been used in the mobile app.