### PR TITLE
[#188]-single submission detail api

### DIFF
--- a/onadata/apps/fsforms/serializers/ConfigureStagesSerializer.py
+++ b/onadata/apps/fsforms/serializers/ConfigureStagesSerializer.py
@@ -311,6 +311,189 @@ class FinstanceSerializer(serializers.ModelSerializer):
         return data
 
 
+class FInstanceDetailSerializer(serializers.ModelSerializer):
+    # instance = InstanceSerializer()
+    submission_data = serializers.SerializerMethodField()
+    submitted_by = serializers.SerializerMethodField()
+    form_type = serializers.SerializerMethodField()
+
+    class Meta:
+        model = FInstance
+        fields = ('submission_data', 'site', 'project', 'site_fxf', 'project_fxf', 'date', 'submitted_by', 'form_type')
+
+    def get_submitted_by(self, obj):
+        return obj.submitted_by.username
+
+    def get_form_type(self, obj):
+        return {
+            'is_staged': obj.site_fxf.is_staged, 'is_scheduled': obj.site_fxf.is_scheduled,
+            'is_survey': obj.site_fxf.is_survey,
+        }
+
+    def get_submission_data(self, obj):
+        data = []
+        json_answer = obj.instance.json
+        json_question = json.loads(obj.site_fxf.xf.json)
+        base_url = BASEURL
+        media_folder = obj.site_fxf.xf.user.username
+
+        def parse_repeat(r_object, prev_group = None):
+            repeat = dict()
+            if prev_group:
+                r_question = prev_group + '/' + r_object['name']
+            else:
+                r_question = r_object['name']
+            repeat['name'] = r_object['name']
+            repeat['type'] = r_object['type']
+            repeat['label'] = r_object.get('label')
+            repeat['elements'] = []
+
+            if r_question in json_answer:
+                for gnr_answer in json_answer[r_question]:
+                    for first_children in r_object['children']:
+                        question_type = first_children['type']
+                        question = first_children['name']
+                        group_answer = json_answer[r_question]
+                        answer = ''
+                        if r_question + "/" + question in gnr_answer:
+                            if first_children['type'] == 'note':
+                                answer = ''
+                            elif first_children['type'] == 'photo' or first_children['type'] == 'audio' or \
+                                    first_children['type'] == 'video':
+                                answer = 'http://' + base_url + '/attachment/medium?media_file=' + media_folder + '/attachments/' + \
+                                         gnr_answer[r_question + "/" + question]
+                            else:
+                                answer = gnr_answer[r_question + "/" + question]
+
+                        if 'label' in first_children:
+                            question = first_children['label']
+                        row = {'type': question_type, 'question': question, 'answer': answer}
+                        repeat['elements'].append(row)
+            elif r_question in json_answer:
+                for gnr_answer in json_answer[r_question]:
+                    for first_children in r_object['children']:
+                        question_type = first_children['type']
+                        question = first_children['name']
+                        group_answer = json_answer[r_question]
+                        answer = ''
+                        if r_question + "/" + question in gnr_answer:
+                            if first_children['type'] == 'note':
+                                answer = ''
+                            elif first_children['type'] == 'photo' or first_children['type'] == 'audio' or \
+                                    first_children['type'] == 'video':
+                                answer = 'http://' + base_url + '/attachment/medium?media_file=' + media_folder + '/attachments/' + \
+                                         gnr_answer[r_question + "/" + question]
+                            else:
+                                answer = gnr_answer[r_question + "/" + question]
+
+                        if 'label' in first_children:
+                            question = first_children['label']
+                        row = {'type': question_type, 'question': question, 'answer': answer}
+                        repeat['elements'].append(row)
+            else:
+                for first_children in r_object['children']:
+                    question_type = first_children['type']
+                    question = first_children['name']
+                    answer = ''
+                    if 'label' in first_children:
+                        question = first_children['label']
+                    row = {'type': question_type, 'question': question, 'answer': answer}
+                    repeat['elements'].append(row)
+            return repeat
+
+        def parse_group(prev_groupname, g_object):
+            g_question = prev_groupname + g_object['name']
+            if g_object['name'] == 'meta':
+                for first_children in g_object['children']:
+                    question = first_children['name']
+                    question_type = first_children['type']
+                    if question_type == 'group':
+                        parse_group(g_question + "/", first_children)
+                        continue
+                    answer = ''
+                    if g_question + "/" + question in json_answer:
+                        if question_type == 'note':
+                            answer = ''
+                        elif question_type == 'photo' or question_type == 'audio' or question_type == 'video':
+                            answer = 'http://' + base_url + '/attachment/medium?media_file=' + media_folder + '/attachments/' + \
+                                     json_answer[g_question + "/" + question]
+                        else:
+                            answer = json_answer[g_question + "/" + question]
+
+                    if 'label' in first_children:
+                        question = first_children['label']
+                    row = {'type': question_type, 'question': question, 'answer': answer}
+                    return row
+            else:
+                group = dict()
+                group['name'] = g_question
+                group['type'] = g_object['type']
+                group['label'] = g_object.get('label')
+                group['elements'] = []
+                # group = {'group_name': g_question, 'type': g_object['type'], 'label': g_object['label']}
+                for first_children in g_object['children']:
+                    question = first_children['name']
+                    question_type = first_children['type']
+                    if question_type == 'group':
+                        group['elements'].append(parse_group(g_question + "/", first_children))
+                        continue
+
+                    if question_type == 'repeat':
+                        group['elements'].append(parse_repeat(first_children, g_question))
+                        continue
+                    answer = ''
+                    if g_question + "/" + question in json_answer:
+                        if question_type == 'note':
+                            answer = ''
+                        elif question_type == 'photo' or question_type == 'audio' or question_type == 'video':
+                            answer = 'http://' + base_url + '/attachment/medium?media_file=' + media_folder + '/attachments/' + \
+                                     json_answer[g_question + "/" + question]
+                        else:
+                            answer = json_answer[g_question + "/" + question]
+
+                    if 'label' in first_children:
+                        question = first_children['label']
+                    row = {'type': question_type, 'question': question, 'answer': answer}
+                    group['elements'].append(row)
+                return group
+
+        def parse_individual_questions(parent_object):
+            for first_children in parent_object:
+                if first_children['type'] == "repeat":
+                    data.append(parse_repeat(first_children))
+                elif first_children['type'] == 'group':
+                    group = parse_group("", first_children)
+                    data.append(group)
+                else:
+                    question = first_children['name']
+                    question_type = first_children['type']
+                    answer = ''
+                    if question in json_answer:
+                        if first_children['type'] == 'note':
+                            answer = ''
+                        elif first_children['type'] == 'photo' or first_children['type'] == 'audio' or first_children[
+                            'type'] == 'video':
+                            answer = 'http://' + base_url + '/attachment/medium?media_file=' + media_folder + '/attachments/' + \
+                                     json_answer[question]
+                        else:
+                            answer = json_answer[question]
+                    if 'label' in first_children:
+                        question = first_children['label']
+                    row = {"type": question_type, "question": question, "answer": answer}
+                    data.append(row)
+
+            submitted_by = {'type': 'submitted_by', 'question': 'Submitted by', 'answer': json_answer['_submitted_by']}
+            submission_time = {
+                'type': 'submission_time', 'question': 'Submission Time',
+                'answer': json_answer['_submission_time']
+            }
+            data.append(submitted_by)
+            data.append(submission_time)
+
+        parse_individual_questions(json_question['children'])
+        return data
+
+
 class FinstanceDataOnlySerializer(serializers.ModelSerializer):
     form_type = serializers.SerializerMethodField()
     submitted_by = serializers.CharField(source='submitted_by.username')

--- a/onadata/apps/fsforms/urls.py
+++ b/onadata/apps/fsforms/urls.py
@@ -1,7 +1,8 @@
 from django.conf.urls import url
 
 from onadata.apps.fsforms.viewsets.FieldSightXformViewset import GeneralFormsViewSet, SurveyFormsViewSet, FormDetailViewset
-from onadata.apps.fsforms.viewsets.InstanceHistoryViewSet import SiteInstanceResponseViewSet, InstanceHistoryViewSet, InstanceResponseViewSet, InstanceHistoryDetailViewSet
+from onadata.apps.fsforms.viewsets.InstanceHistoryViewSet import SiteInstanceResponseViewSet, InstanceHistoryViewSet,\
+    InstanceResponseViewSet, InstanceHistoryDetailViewSet, InstanceDetailViewSet
 from onadata.apps.fsforms.viewsets.ScheduleViewset import ScheduleViewset, DayViewset
 from onadata.apps.fsforms.viewsets.AssignedXFormListApiViewSet import AssignedXFormListApi
 from onadata.apps.fsforms.viewsets.FSXFormSubmissionApiViewset import FSXFormSubmissionApi, ProjectFSXFormSubmissionApi
@@ -235,6 +236,7 @@ urlpatterns = urlpatterns + [
     url(r'^api/responses/(?P<pk>\d+)/$', InstanceResponseViewSet.as_view({'get': 'list'})),
     url(r'^api/responses/(?P<form_pk>\d+)/(?P<site_pk>\d+)/$', SiteInstanceResponseViewSet.as_view({'get': 'list'})),
     url(r'^api/form-detail/(?P<pk>\d+)/$', FormDetailViewset.as_view({'get': 'retrieve'})),
+    url(r'^api/instance/(?P<pk>\d+)/$', InstanceDetailViewSet.as_view({'get': 'list'})),
 
     url(r'^api/stage-list/(?P<is_project>\d)/(?P<pk>\d+)/$', StageListViewSet.as_view({'post': 'create','get': 'list'})),
     url(r'^api/configure-stage-update/(?P<pk>\d+)/$', StageListViewSet.as_view({'put': 'update','get': 'retrieve_by_id'})),

--- a/onadata/apps/fsforms/viewsets/InstanceHistoryViewSet.py
+++ b/onadata/apps/fsforms/viewsets/InstanceHistoryViewSet.py
@@ -3,6 +3,7 @@ from rest_framework import viewsets
 
 from onadata.apps.fsforms.models import InstanceStatusChanged, FInstance
 from onadata.apps.fsforms.serializers.InstanceStatusChangedSerializer import InstanceStatusChangedSerializer, FInstanceResponcesSerializer
+from onadata.apps.fsforms.serializers.ConfigureStagesSerializer import FinstanceSerializer, FInstanceDetailSerializer
 from rest_framework.pagination import PageNumberPagination
 from onadata.apps.fsforms.models import FieldSightXF
 from django.http import Http404
@@ -53,3 +54,11 @@ class SiteInstanceResponseViewSet(viewsets.ModelViewSet):
             return queryset.filter(site_id=self.kwargs.get('site_pk'), project_fxf_id=self.kwargs.get('form_pk')).order_by('-date')
         return queryset.filter(site_id=self.kwargs.get('site_pk'), site_fxf_id=self.kwargs.get('form_pk')).order_by('-date')
 
+
+class InstanceDetailViewSet(viewsets.ModelViewSet):
+    queryset = FInstance.objects.all()
+    serializer_class = FInstanceDetailSerializer
+    pagination_class = LargeResultsSetPagination
+
+    def filter_queryset(self, queryset):
+        return queryset.filter(pk=self.kwargs.get('pk'))


### PR DESCRIPTION
API url: *forms/api/instance/<finstance_id>/*

Handled the following cases:
 +  Individual question(not groups and repeats) and answer
 + For groups: 
    + Display `type`, `name of group`(Data Column Name in kpi), `label of group`(group name seen) and `elements`(question, answer and type of each element inside the group)
    + Sub groups inside groups with detail as same format of a group. `name of group` as `group_name/sub_group_name`
    + Repeating groups inside groups
 + Repeating groups
 + Other regular information like submission date, submitted by, version, uuid, form_type, etc.