### PR TITLE
Share form api

### DIFF
--- a/onadata/apps/fsforms/models.py
+++ b/onadata/apps/fsforms/models.py
@@ -382,10 +382,9 @@ def create_messages(sender, instance, created,  **kwargs):
         if task_obj:
             try:
                 with transaction.atomic():
-                    share_form_managers.delay(instance.id, task_obj.id)
+                    share_form_managers.apply_async(kwargs={'fxf': instance.id, 'task_id': task_obj.id}, countdown=5)
             except IntegrityError as e:
                 print(e)
-
 
 @receiver(pre_delete, sender=FieldSightXF)
 def send_delete_message(sender, instance, using, **kwargs):

--- a/onadata/apps/fv3/serializers/SubmissionSerializer.py
+++ b/onadata/apps/fv3/serializers/SubmissionSerializer.py
@@ -141,14 +141,17 @@ class SubmissionSerializer(serializers.ModelSerializer):
                     "comment": c.message,
                     "date": c.date,
                     "get_new_status_display": "Rejected",
-                    "user_name": "fsadmin"
+                    "user_name": c.user.user_name,
+                    "url": reverse_lazy("forms:instance_status_change_detail",
+                                                kwargs={'pk': c.id}),
                 },
                 )
         instances_data = []
         for fi in finstances:
             instances_data.append(
-                {"comment": reverse_lazy("fv3:submission", args=(fi.id,)),
+                {"url": reverse_lazy("fv3:submission", args=(fi.id,)),
                  "date": fi.date,
+                 "comment": "",
                  "get_new_status_display": "New Submission",
                  "user_name":fi.submitted_by.username})
         # sort data past _ data

--- a/onadata/apps/main/models/meta_data.py
+++ b/onadata/apps/main/models/meta_data.py
@@ -122,7 +122,10 @@ class MetaData(models.Model):
 
     def save(self, *args, **kwargs):
         self._set_hash()
-        super(MetaData, self).save(*args, **kwargs)
+        if MetaData.objects.filter(xform=self.xform,data_type=self.data_type, data_value=self.data_value).exists():
+            pass
+        else:
+            super(MetaData, self).save(*args, **kwargs)
 
     @property
     def hash(self):

--- a/onadata/apps/userrole/models.py
+++ b/onadata/apps/userrole/models.py
@@ -216,7 +216,7 @@ def create_messages(sender, instance, created,  **kwargs):
         if task_obj:
             try:
                 with transaction.atomic():
-                    created_manager_form_share.delay(instance.id, task_obj.id)
+                    created_manager_form_share.apply_async(kwargs={'userrole': instance.id, 'task_id': task_obj.id}, countdown=5)
             except IntegrityError:
                 pass
 


### PR DESCRIPTION
The celery task was throwing a **Matching query not found error** when new form was assigned to a project, which resulted in the sharing of the assigned form to projects manager fail.

This was because of use of atomic transaction being used to call the task from post save signal. 

Tried to delay the task call by using `apply_async`