### PR TITLE
Share Forms APIs and Management command

### DIFF
--- a/onadata/apps/fsforms/migrations/0075_sharedfieldsightform.py
+++ b/onadata/apps/fsforms/migrations/0075_sharedfieldsightform.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fsforms', '0074_merge'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SharedFieldSightForm',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('shared', models.BooleanField(default=False)),
+                ('fxf', models.OneToOneField(to='fsforms.FieldSightXF')),
+            ],
+        ),
+    ]

--- a/onadata/apps/fsforms/migrations/0076_auto_20190620_1753.py
+++ b/onadata/apps/fsforms/migrations/0076_auto_20190620_1753.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('logger', '0008_auto_20190418_1608'),
+        ('fsforms', '0075_sharedfieldsightform'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='sharedfieldsightform',
+            name='fxf',
+        ),
+        migrations.AddField(
+            model_name='sharedfieldsightform',
+            name='xf',
+            field=models.OneToOneField(null=True, to='logger.XForm'),
+        ),
+    ]

--- a/onadata/apps/fsforms/models.py
+++ b/onadata/apps/fsforms/models.py
@@ -1008,10 +1008,10 @@ class Asset(models.Model):
 
 
 class SharedFieldSightForm(models.Model):
-    fxf = models.OneToOneField(FieldSightXF)
+    xf = models.OneToOneField(XForm, null=True)
     shared = models.BooleanField(default=False)
 
     def get_shareable_link(self):
-        return settings.KPI_URL + '#/forms/' + self.fxf.xf.id_string
+        return settings.KPI_URL + '#/forms/' + self.xf.id_string
 
 

--- a/onadata/apps/fsforms/models.py
+++ b/onadata/apps/fsforms/models.py
@@ -4,6 +4,7 @@ import os
 
 import json
 import re
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.postgres.fields import ArrayField
@@ -1003,6 +1004,14 @@ class Asset(models.Model):
 
     class Meta:
         db_table = 'kpi_asset'
-        managed = False 
+        managed = False
+
+
+class SharedFieldSightForm(models.Model):
+    fxf = models.OneToOneField(FieldSightXF)
+    shared = models.BooleanField(default=False)
+
+    def get_shareable_link(self):
+        return settings.KPI_URL + '#/forms/' + self.fxf.xf.id_string
 
 

--- a/onadata/apps/fsforms/models.py
+++ b/onadata/apps/fsforms/models.py
@@ -1001,6 +1001,7 @@ class ObjectPermission(models.Model):
 class Asset(models.Model):
     uid = KpiUidField(uid_prefix='a')
     owner = models.ForeignKey('auth.User', related_name='assets', null=True)
+    content = JSONField(null=True)
 
     class Meta:
         db_table = 'kpi_asset'

--- a/onadata/apps/fsforms/share_xform.py
+++ b/onadata/apps/fsforms/share_xform.py
@@ -68,13 +68,13 @@ def share_form(users, xform):
     return True
 
 
-def share_form_global(xform):
-    from onadata.apps.fsforms.models import ObjectPermission, Asset
+def share_form_global(form):
+    from onadata.apps.fsforms.models import ObjectPermission, Asset, SharedFieldSightForm
     codenames = ['view_asset', 'view_submissions']
     permissions = Permission.objects.filter(content_type__app_label='kpi', codename__in=codenames)
     for perm in permissions:
-        object_id = Asset.objects.get(uid=xform.id_string).id
-        content_type = ContentType.objects.get(id=20)  # change id as per the content type for asset
+        object_id = Asset.objects.get(uid=form.xf.id_string).id
+        content_type = ContentType.objects.get(id=21)  # change id as per the content type for asset
         user = User.objects.get(id=-1)
         if not ObjectPermission.objects.filter(
             object_id=object_id,
@@ -90,6 +90,9 @@ def share_form_global(xform):
                 permission_id=perm.pk,
                 deny=False,
                 inherited=False)
+            shared, created = SharedFieldSightForm.objects.get_or_create(fxf=form, shared=True)
+            if not created:
+                SharedFieldSightForm.objects.filter(fxf=form).update(shared=True)
         else:
             continue
     return True

--- a/onadata/apps/fsforms/share_xform.py
+++ b/onadata/apps/fsforms/share_xform.py
@@ -1,6 +1,7 @@
 from guardian.shortcuts import assign_perm, get_users_with_perms
 from django.contrib.auth.models import Permission, User
 from django.contrib.contenttypes.models import ContentType
+from django.conf import settings
 
 
 def share_m2m(users, forms):
@@ -19,7 +20,7 @@ def share_forms(user, forms):
         permissions = Permission.objects.filter(content_type__app_label='kpi', codename__in=codenames)
         for perm in permissions:
             object_id = Asset.objects.get(uid=fxf.xf.id_string).id
-            content_type = ContentType.objects.get(id=20)  # change id as per the content type for asset
+            content_type = ContentType.objects.get(id=settings.ASSET_CONTENT_TYPE_ID)
 
             # Create the new permission
             if not ObjectPermission.objects.filter(object_id=object_id,
@@ -47,7 +48,7 @@ def share_form(users, xform):
         permissions = Permission.objects.filter(content_type__app_label='kpi', codename__in=codenames)
         for perm in permissions:
             object_id = Asset.objects.get(uid=xform.id_string).id
-            content_type = ContentType.objects.get(id=20)  # change id as per the content type for asset
+            content_type = ContentType.objects.get(id=settings.ASSET_CONTENT_TYPE_ID)
 
             # Create the new permission
             if not ObjectPermission.objects.filter(object_id=object_id,
@@ -74,7 +75,7 @@ def share_form_global(form):
     permissions = Permission.objects.filter(content_type__app_label='kpi', codename__in=codenames)
     for perm in permissions:
         object_id = Asset.objects.get(uid=form.id_string).id
-        content_type = ContentType.objects.get(id=20)  # change id as per the content type for asset
+        content_type = ContentType.objects.get(id=settings.ASSET_CONTENT_TYPE_ID)
         user = User.objects.get(id=-1)
         if not ObjectPermission.objects.filter(
             object_id=object_id,

--- a/onadata/apps/fsforms/share_xform.py
+++ b/onadata/apps/fsforms/share_xform.py
@@ -73,8 +73,8 @@ def share_form_global(form):
     codenames = ['view_asset', 'view_submissions']
     permissions = Permission.objects.filter(content_type__app_label='kpi', codename__in=codenames)
     for perm in permissions:
-        object_id = Asset.objects.get(uid=form.xf.id_string).id
-        content_type = ContentType.objects.get(id=21)  # change id as per the content type for asset
+        object_id = Asset.objects.get(uid=form.id_string).id
+        content_type = ContentType.objects.get(id=20)  # change id as per the content type for asset
         user = User.objects.get(id=-1)
         if not ObjectPermission.objects.filter(
             object_id=object_id,
@@ -90,9 +90,9 @@ def share_form_global(form):
                 permission_id=perm.pk,
                 deny=False,
                 inherited=False)
-            shared, created = SharedFieldSightForm.objects.get_or_create(fxf=form, shared=True)
+            shared, created = SharedFieldSightForm.objects.get_or_create(xf=form, shared=True)
             if not created:
-                SharedFieldSightForm.objects.filter(fxf=form).update(shared=True)
+                SharedFieldSightForm.objects.filter(xf=form).update(shared=True)
         else:
             continue
     return True

--- a/onadata/apps/fsforms/tasks.py
+++ b/onadata/apps/fsforms/tasks.py
@@ -196,10 +196,10 @@ def created_manager_form_share(userrole, task_id):
 
 
 @shared_task(max_retries=5)
-def api_share_form(fxf, users, task_id):
-    fxf = FieldSightXF.objects.get(pk=fxf)
+def api_share_form(xf, users, task_id):
+    xf = XForm.objects.get(pk=xf)
     users = User.objects.filter(id__in=users)
-    shared = share_form(users, fxf.xf)
+    shared = share_form(users, xf)
     if shared:
         CeleryTaskProgress.objects.filter(id=task_id).update(status=2)
     else:

--- a/onadata/apps/fv3/permissions/xform.py
+++ b/onadata/apps/fv3/permissions/xform.py
@@ -14,8 +14,8 @@ class XFormSharePermission(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         user = request.user
         permission = Permission.objects.get(content_type__app_label='kpi', codename='share_asset')
-        content_type = ContentType.objects.get(id=21)
-        object = Asset.objects.get(uid=obj.xf.id_string)
+        content_type = ContentType.objects.get(id=20)
+        object = Asset.objects.get(uid=obj.id_string)
 
         if user == object.owner or ObjectPermission.objects.filter(
                 object_id=object.id,

--- a/onadata/apps/fv3/serializers/FormSerializer.py
+++ b/onadata/apps/fv3/serializers/FormSerializer.py
@@ -31,6 +31,18 @@ class XFormSerializer(serializers.ModelSerializer):
     def get_media_url(self, obj):
         return "{}/{}/forms/{}/form_settings".format(settings.KOBOCAT_URL, obj.user.username, obj.id_string)
 
+    def get_share_users_url(self):
+        return "{}/fv3/api/share/".format(settings.KOBOCAT_URL)
+
+    def get_share_project_url(self):
+        return "{}/fv3/api/share/project/".format(settings.KOBOCAT_URL)
+
+    def get_share_team_url(self):
+        return "{}/fv3/api/share/team/".format(settings.KOBOCAT_URL)
+
+    def get_share_global_url(self):
+        return "{}/fv3/api/share/global/".format(settings.KOBOCAT_URL)
+
 
 class ShareFormSerializer(serializers.Serializer):
     form = serializers.IntegerField()

--- a/onadata/apps/fv3/serializers/FormSerializer.py
+++ b/onadata/apps/fv3/serializers/FormSerializer.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from onadata.apps.logger.models import XForm
-
+from onadata.apps.fsforms.models import Asset
 from django.conf import settings
 
 
@@ -15,6 +15,7 @@ class XFormSerializer(serializers.ModelSerializer):
     share_project_url = serializers.SerializerMethodField()
     share_team_url = serializers.SerializerMethodField()
     share_global_url = serializers.SerializerMethodField()
+    add_language_url = serializers.SerializerMethodField()
 
     class Meta:
         model = XForm
@@ -47,6 +48,9 @@ class XFormSerializer(serializers.ModelSerializer):
     def get_share_global_url(self):
         return "{}/fv3/api/share/global/".format(settings.KOBOCAT_URL)
 
+    def get_add_language_url(self):
+        return "{}/fv3/api/add-language/".format(settings.KOBOCAT_URL)
+
 
 class ShareFormSerializer(serializers.Serializer):
     form = serializers.IntegerField()
@@ -65,3 +69,11 @@ class ShareTeamFormSerializer(serializers.Serializer):
 
 class ShareGlobalFormSerializer(serializers.Serializer):
     form = serializers.IntegerField()
+
+
+class AddLanguageSerializer(serializers.Serializer):
+    form = serializers.IntegerField()
+    language = serializers.CharField()
+    code = serializers.CharField()
+
+

--- a/onadata/apps/fv3/urls.py
+++ b/onadata/apps/fv3/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import url
 
 from onadata.apps.fv3.views import supervisor_projects, MySuperviseSitesViewset, site_blueprints, supervisor_logs
 from onadata.apps.fv3.viewsets.FormsViewset import MyFormsViewSet, MyProjectFormsViewSet, ShareFormViewSet, \
-    ShareProjectFormViewSet, ShareTeamFormViewSet, ShareGlobalFormViewSet
+    ShareProjectFormViewSet, ShareTeamFormViewSet, ShareGlobalFormViewSet, FormAddLanguageViewSet
 from onadata.apps.fv3.viewsets.ReportViewsets import ReportVs
 from onadata.apps.fv3.viewsets.SubmissionViewSet import SubmissionViewSet, AlterSubmissionStatusViewSet, \
     SubmissionAnswerViewSet, SubmissionViewSet
@@ -30,6 +30,8 @@ urlpatterns = [
     url(r'^api/share/global/$', ShareGlobalFormViewSet.as_view(), name='share_global_form'),
 
     url(r'^api/report/$', ReportVs.as_view({'post':'create'}), name='report'),
+
+    url(r'^api/add-language/$', FormAddLanguageViewSet.as_view(), name='add_language'),
     ]
 
 

--- a/onadata/apps/fv3/viewsets/FormsViewset.py
+++ b/onadata/apps/fv3/viewsets/FormsViewset.py
@@ -65,16 +65,16 @@ class ShareFormViewSet(APIView):
     def post(self, request, **kwargs):
         serializer = ShareFormSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        fxf = FieldSightXF.objects.get(pk=request.data['form'])
-        self.check_object_permissions(request, fxf)
+        xf = XForm.objects.get(pk=request.data['form'])
+        self.check_object_permissions(request, xf)
         task_obj = CeleryTaskProgress.objects.create(user=request.user,
                                                      description="Share Forms Individual",
-                                                     task_type=19, content_object=fxf)
+                                                     task_type=19, content_object=xf)
         if task_obj:
             from onadata.apps.fsforms.tasks import api_share_form
             try:
                 with transaction.atomic():
-                    api_share_form.delay(fxf.id, request.data['users'], task_obj.id)
+                    api_share_form.delay(xf.id, request.data['users'], task_obj.id)
             except IntegrityError:
                 pass
         return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -91,11 +91,11 @@ class ShareProjectFormViewSet(APIView):
     def post(self, request, **kwargs):
         serializer = ShareProjectFormSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        fxf = FieldSightXF.objects.get(pk=request.data['form'])
-        self.check_object_permissions(request, fxf)
+        xf = XForm.objects.get(pk=request.data['form'])
+        self.check_object_permissions(request, xf)
         task_obj = CeleryTaskProgress.objects.create(user=request.user,
                                                      description="Share Forms Project Manager and Admin",
-                                                     task_type=20, content_object=fxf)
+                                                     task_type=20, content_object=xf)
         if task_obj:
             from onadata.apps.fsforms.tasks import api_share_form
             try:
@@ -109,7 +109,7 @@ class ShareProjectFormViewSet(APIView):
                     user_ids = []
                     for item in users:
                         user_ids.append(item.id)
-                    api_share_form.delay(fxf.id, user_ids, task_obj.id)
+                    api_share_form.delay(xf.id, user_ids, task_obj.id)
             except IntegrityError:
                 pass
         return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -126,10 +126,10 @@ class ShareTeamFormViewSet(APIView):
     def post(self, request, **kwargs):
         serializer = ShareTeamFormSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        fxf = FieldSightXF.objects.get(pk=request.data['form'])
-        self.check_object_permissions(request, fxf)
+        xf = XForm.objects.get(pk=request.data['form'])
+        self.check_object_permissions(request, xf)
         task_obj = CeleryTaskProgress.objects.create(user=request.user, description="Share XForm to Team",
-                                                     task_type=21, content_object=fxf)
+                                                     task_type=21, content_object=xf)
         if task_obj:
             from onadata.apps.fsforms.tasks import api_share_form
             try:
@@ -141,7 +141,7 @@ class ShareTeamFormViewSet(APIView):
                     user_ids = []
                     for item in users:
                         user_ids.append(item.id)
-                    api_share_form.delay(fxf.id, user_ids, task_obj.id)
+                    api_share_form.delay(xf.id, user_ids, task_obj.id)
             except IntegrityError:
                 pass
         return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -158,12 +158,12 @@ class ShareGlobalFormViewSet(APIView):
     def post(self, request, **kwargs):
         serializer = ShareGlobalFormSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
-        fxf = FieldSightXF.objects.get(pk=request.data['form'])
-        self.check_object_permissions(request, fxf)
+        xf = XForm.objects.get(pk=request.data['form'])
+        self.check_object_permissions(request, xf)
 
         from onadata.apps.fsforms.share_xform import share_form_global
-        shared = share_form_global(fxf)
+        shared = share_form_global(xf)
         if shared:
-            return Response({'share_link': settings.KPI_URL + '#/forms/' + fxf.xf.id_string}, status=status.HTTP_201_CREATED)
+            return Response({'share_link': settings.KPI_URL + '#/forms/' + xf.id_string}, status=status.HTTP_201_CREATED)
 
 

--- a/onadata/apps/fv3/viewsets/FormsViewset.py
+++ b/onadata/apps/fv3/viewsets/FormsViewset.py
@@ -162,11 +162,8 @@ class ShareGlobalFormViewSet(APIView):
         self.check_object_permissions(request, fxf)
 
         from onadata.apps.fsforms.share_xform import share_form_global
-        shared = share_form_global(fxf.xf)
+        shared = share_form_global(fxf)
         if shared:
             return Response({'share_link': settings.KPI_URL + '#/forms/' + fxf.xf.id_string}, status=status.HTTP_201_CREATED)
-
-
-
 
 


### PR DESCRIPTION
**NOTE:** Add `ASSET_CONTENT_TYPE_ID` in the local_settings.py file where:

    ASSET_CONTENT_TYPE_ID = <content_type_id_for_asset_model>

**content_type_id_for_asset_model** can be obtained as:

    from django.contrib.contenttypes.models import ContentType
    content_type_id_for_asset_model = ContentType.objects.get(app_label="kpi", model="asset").id


Management command to share forms of a project to the existing project managers and organization admin of the same project.

 - Takes the project id as an argument.

The apis for form share are:
 - `/fv3/api/share/` **# for individuals**
 - `/fv3/api/share/project/`  **# for project**
 - `/fv3/api/share/team/` **# for team**
 - `/fv3/api/share/global/` **# for global sharing**

**The form is shared globally means that the form can be viewed by everyone if they go to the url(kpi_url/#/forms/<form_uid>/) but the form is not displayed in their project dashboards.**

-------------------------------------------------------------------------------------------------------------------------------------------
###  - Created a model `SharedFieldSightForm` to keep the shared state of a form.
###  - `get_shareable_link()` provides the link of the publicly shared form.
-------------------------------------------------------------------------------------------------------------------------------------------
-------------------------------------------------------------------------------------------------------------------------------------------
 ### Added language add api for the forms.

*POST data format*
    
    {
        "form": <xform_id>,
        "language": <name_of_language>
        "code": <standard_code_defined_for_language, e.g., ne for Nepali>
    }
-------------------------------------------------------------------------------------------------------------------------------------------