### PR TITLE
Initial: History for site meta attributes answer

### DIFF
--- a/onadata/apps/eventlog/migrations/0058_auto_20190719_1710.py
+++ b/onadata/apps/eventlog/migrations/0058_auto_20190719_1710.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('eventlog', '0057_auto_20190708_1055'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='celerytaskprogress',
+            name='task_type',
+            field=models.IntegerField(default=0, choices=[(0, 'Bulk Site Update'), (1, 'User Assign to Project'), (2, 'User Assign to Site'), (3, 'Site Response Xls Report'), (4, 'Site Import'), (6, 'Zip Site Images'), (7, 'Remove Roles'), (8, 'Site Data Export'), (9, 'Response Pdf Report'), (10, 'Site Progress Xls Report'), (11, 'Project Statstics Report'), (12, 'Log Report'), (13, 'User Assign to Region'), (14, 'User Assign to an entire project'), (15, 'Auto Clone and Deploy General Form'), (16, 'User Activity Xls Report'), (17, 'Share XForm'), (18, 'Share XForm to Created Manager'), (19, 'Share XForm to Individuals'), (20, 'Share XForm to Project Managers and Admin of Project'), (21, 'Share XForm to team'), (22, 'Clone Form'), (22, 'Update Sites Progress'), (23, 'Update Site Progress'), (24, 'Update and Create History of Site Meta-attributes Answers')]),
+        ),
+    ]

--- a/onadata/apps/eventlog/migrations/0059_auto_20190723_1004.py
+++ b/onadata/apps/eventlog/migrations/0059_auto_20190723_1004.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('eventlog', '0058_auto_20190719_1710'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='celerytaskprogress',
+            name='task_type',
+            field=models.IntegerField(default=0, choices=[(0, 'Bulk Site Update'), (1, 'User Assign to Project'), (2, 'User Assign to Site'), (3, 'Site Response Xls Report'), (4, 'Site Import'), (6, 'Zip Site Images'), (7, 'Remove Roles'), (8, 'Site Data Export'), (9, 'Response Pdf Report'), (10, 'Site Progress Xls Report'), (11, 'Project Statstics Report'), (12, 'Log Report'), (13, 'User Assign to Region'), (14, 'User Assign to an entire project'), (15, 'Auto Clone and Deploy General Form'), (16, 'User Activity Xls Report'), (17, 'Share XForm'), (18, 'Share XForm to Created Manager'), (19, 'Share XForm to Individuals'), (20, 'Share XForm to Project Managers and Admin of Project'), (21, 'Share XForm to team'), (22, 'Clone Form'), (22, 'Update Sites Progress'), (23, 'Update Site Progress'), (24, 'Update and Create History of Site Meta-attributes Answers'), (25, 'Update Site Information on Submission')]),
+        ),
+    ]

--- a/onadata/apps/eventlog/models.py
+++ b/onadata/apps/eventlog/models.py
@@ -234,6 +234,7 @@ class CeleryTaskProgress(models.Model):
         (22, 'Clone Form'),
         (22, 'Update Sites Progress'),
         (23, 'Update Site Progress'),
+        (24, 'Update and Create History of Site Meta-attributes Answers')
 
     )
     task_id = models.CharField(max_length=255, blank=True, null=True)

--- a/onadata/apps/eventlog/models.py
+++ b/onadata/apps/eventlog/models.py
@@ -234,7 +234,8 @@ class CeleryTaskProgress(models.Model):
         (22, 'Clone Form'),
         (22, 'Update Sites Progress'),
         (23, 'Update Site Progress'),
-        (24, 'Update and Create History of Site Meta-attributes Answers')
+        (24, 'Update and Create History of Site Meta-attributes Answers'),
+        (25, 'Update Site Information on Submission'),
 
     )
     task_id = models.CharField(max_length=255, blank=True, null=True)

--- a/onadata/apps/eventlog/views.py
+++ b/onadata/apps/eventlog/views.py
@@ -76,7 +76,7 @@ class MyTaskListViewSet(viewsets.ModelViewSet):
         profile.task_last_view_date = datetime.now()
         profile.save()
 
-        exclude_task_type = [15, 17, 18, 19, 20, 21, 22, 23, 24]
+        exclude_task_type = [15, 17, 18, 19, 20, 21, 22, 23, 24, 25]
         
         if self.request.is_super_admin:
             return queryset.order_by('-date_updateded')

--- a/onadata/apps/eventlog/views.py
+++ b/onadata/apps/eventlog/views.py
@@ -76,7 +76,7 @@ class MyTaskListViewSet(viewsets.ModelViewSet):
         profile.task_last_view_date = datetime.now()
         profile.save()
 
-        exclude_task_type = [15, 17, 18, 19, 20, 21, 22, 23]
+        exclude_task_type = [15, 17, 18, 19, 20, 21, 22, 23, 24]
         
         if self.request.is_super_admin:
             return queryset.order_by('-date_updateded')

--- a/onadata/apps/fieldsight/migrations/0097_auto_20190719_1628.py
+++ b/onadata/apps/fieldsight/migrations/0097_auto_20190719_1628.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('fieldsight', '0096_auto_20190717_1437'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SiteMetaAttrAnsHistory',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('meta_attributes_ans', jsonfield.fields.JSONField(default={})),
+                ('date', models.DateTimeField(auto_now=True)),
+                ('status', models.IntegerField(blank=True, null=True, choices=[(1, 'By submission'), (2, 'By change in meta attributes')])),
+                ('site', models.ForeignKey(related_name='meta_history', to='fieldsight.Site')),
+            ],
+            options={
+                'ordering': ['-date'],
+            },
+        ),
+        migrations.RemoveField(
+            model_name='sitemetaattrhistory',
+            name='site',
+        ),
+        migrations.DeleteModel(
+            name='SiteMetaAttrHistory',
+        ),
+    ]

--- a/onadata/apps/fieldsight/models.py
+++ b/onadata/apps/fieldsight/models.py
@@ -794,10 +794,17 @@ class SiteProgressHistory(models.Model):
         return "{} {}".format(self.site.name, self.progress)
 
 
+META_CHANGE_STATUS_CHANGES = (
+    (1, 'By submission'),
+    (2, 'By change in met attributes')
+)
+
+
 class SiteMetaAttrAnsHistory(models.Model):
     meta_attributes_ans = JSONField(default=dict)
     site = models.ForeignKey(Site, related_name="meta_history")
     date = models.DateTimeField(auto_now=True)
+    status = models.IntegerField(choices=META_CHANGE_STATUS_CHANGES, null=True, blank=True)
 
     class Meta:
         ordering = ['-date']

--- a/onadata/apps/fieldsight/models.py
+++ b/onadata/apps/fieldsight/models.py
@@ -795,7 +795,7 @@ class SiteProgressHistory(models.Model):
 
 
 class SiteMetaAttrAnsHistory(models.Model):
-    meta_attributes = JSONField(default=dict)
+    meta_attributes_ans = JSONField(default=dict)
     site = models.ForeignKey(Site, related_name="meta_history")
     date = models.DateTimeField(auto_now=True)
 

--- a/onadata/apps/fieldsight/models.py
+++ b/onadata/apps/fieldsight/models.py
@@ -794,17 +794,17 @@ class SiteProgressHistory(models.Model):
         return "{} {}".format(self.site.name, self.progress)
 
 
-META_CHANGE_STATUS_CHANGES = (
+META_CHANGE_STATUS = (
     (1, 'By submission'),
-    (2, 'By change in met attributes')
+    (2, 'By change in meta attributes')
 )
 
 
 class SiteMetaAttrAnsHistory(models.Model):
-    meta_attributes_ans = JSONField(default=dict)
+    meta_attributes_ans = JSONField(default={})
     site = models.ForeignKey(Site, related_name="meta_history")
     date = models.DateTimeField(auto_now=True)
-    status = models.IntegerField(choices=META_CHANGE_STATUS_CHANGES, null=True, blank=True)
+    status = models.IntegerField(choices=META_CHANGE_STATUS, null=True, blank=True)
 
     class Meta:
         ordering = ['-date']

--- a/onadata/apps/fieldsight/models.py
+++ b/onadata/apps/fieldsight/models.py
@@ -794,8 +794,8 @@ class SiteProgressHistory(models.Model):
         return "{} {}".format(self.site.name, self.progress)
 
 
-class SiteMetaAttrHistory(models.Model):
-    meta_attributes = JSONField(default=list)
+class SiteMetaAttrAnsHistory(models.Model):
+    meta_attributes = JSONField(default=dict)
     site = models.ForeignKey(Site, related_name="meta_history")
     date = models.DateTimeField(auto_now=True)
 

--- a/onadata/apps/fieldsight/tasks.py
+++ b/onadata/apps/fieldsight/tasks.py
@@ -2602,3 +2602,73 @@ def create_site_meta_attribs_ans_history(pk, task_id):
         CeleryTaskProgress.objects.filter(id=task_id).update(status=2)
     except Exception:
         CeleryTaskProgress.objects.filter(id=task_id).update(status=3)
+
+
+@shared_task(max_retries=5, time_limit=300, soft_time_limit=300)
+def update_meta_details(fs_proj_xf_id, instance_id, task_id):
+    try:
+        instance = Instance.objects.get(id=instance_id)
+        fs_proj_xf = FieldSightXF.objects.get(id=fs_proj_xf_id)
+        site = fs_proj_xf.site
+        if fs_proj_xf.id in fs_proj_xf.project.site_basic_info.get('active_forms', []):
+            site_picture = site.project.site_basic_info.get('site_picture', None)
+            if site_picture and site_picture.get('question_type', '') == 'form' and site_picture.get('form_id',
+                                                                                                     0) > fs_proj_xf.id and site_picture.get(
+                    'question', {}):
+                question_name = site_picture['question'].get('question_name', '')
+                logo_url = instance.json.get(question_name)
+                if logo_url:
+                    site.logo_url.name = logo_url
+
+            site_loc = fs_proj_xf.project.site_basic_info.get('site_location', None)
+            if site_loc and site_loc.get('question_type', '') == 'form' and site_loc.get('form_id',
+                                                                                         0) > fs_proj_xf.id and site_loc.get(
+                    'question', {}):
+                question_name = site_loc['question'].get('question_name', '')
+                location = instance.json.get(question_name)
+                if location:
+                    site.location = location
+
+            for featured_img in fs_proj_xf.project.site_featured_images:
+                if featured_img.get('question_type', '') == 'form' and featured_img.get('form_id',
+                                                                                        0) > fs_proj_xf.id and featured_img.get(
+                        'question', {}):
+
+                    question_name = featured_img['question'].get('question_name', '')
+                    logo_url = instance.json.get(question_name)
+                    if logo_url:
+                        site.site_featured_images[question_name] = logo_url
+
+        # change site meta attributes answer
+        meta_ans = site.site_meta_attributes_ans
+        for item in fs_proj_xf.project.site_meta_attributes:
+            if item.get('question_type') == 'Form' and fs_proj_xf.id == item.get('form_id', 0):
+                if item['question']['type'] == "repeat":
+                    answer = ""
+                else:
+                    answer = instance.get(item.get('question').get('name'), '')
+                if item['question']['type'] in ['photo', 'video', 'audio'] and answer is not "":
+                    answer = 'http://app.fieldsight.org/attachment/medium?media_file=' + fs_proj_xf.xf.user.username + '/attachments/' + answer
+                meta_ans[item['question_name']] = answer
+
+            elif item.get('question_type') == 'FormSubStat' and fs_proj_xf.id == item.get('form_id', 0):
+                answer = "Last submitted on " + instance.date.strftime("%d %b %Y %I:%M %P")
+                meta_ans[item['question_name']] = answer
+
+            elif item.get('question_type') == "FormQuestionAnswerStatus":
+                get_answer = instance.json.get(item.get('question').get('name'), None)
+                if get_answer:
+                    answer = "Answered"
+                else:
+                    answer = ""
+                meta_ans[item['question_name']] = answer
+
+            elif item.get('question_type') == "FormSubCountQuestion":
+                meta_ans[item['question_name']] = fs_proj_xf.project_form_instances.filter(site_id=site.id).count()
+
+        SiteMetaAttrAnsHistory.objects.create(site=site, meta_attributes_ans=site.site_meta_attributes_ans, status=1)
+        site.site_meta_attributes_ans = meta_ans
+        site.save()
+        CeleryTaskProgress.objects.filter(id=task_id).update(status=2)
+    except:
+        CeleryTaskProgress.objects.filter(id=task_id).update(status=3)

--- a/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
+++ b/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
@@ -11,9 +11,9 @@ from rest_framework import status
 
 from onadata.apps.api.viewsets.xform_submission_api import XFormSubmissionApi
 from onadata.apps.eventlog.models import FieldSightLog
-from onadata.apps.fieldsight.models import Site
+from onadata.apps.fieldsight.models import Site, SiteMetaAttrAnsHistory
 from onadata.apps.fsforms.models import FieldSightXF, Stage, Schedule, SubmissionOfflineSite, FInstance, \
-    EditedSubmission, SiteMetaAttrAnsHistory
+    EditedSubmission
 from onadata.apps.fsforms.serializers.FieldSightSubmissionSerializer import FieldSightSubmissionSerializer
 from ..fieldsight_logger_tools import safe_create_instance
 from channels import Group as ChannelGroup
@@ -57,7 +57,7 @@ def update_meta_details(fs_proj_xf, instance):
         # change site meta attributes answer
         meta_ans = site.site_meta_attributes_ans
         for item in fs_proj_xf.project.site_meta_attributes:
-            if item.get('question_type', '') == 'Form' and fs_proj_xf.id == item.get('form_id', 0):
+            if item.get('question_type') == 'Form' and fs_proj_xf.id == item.get('form_id', 0):
                 if item['question']['type'] == "repeat":
                     answer = ""
                 else:
@@ -65,6 +65,21 @@ def update_meta_details(fs_proj_xf, instance):
                 if item['question']['type'] in ['photo', 'video', 'audio'] and answer is not "":
                     answer = 'http://app.fieldsight.org/attachment/medium?media_file=' + fs_proj_xf.xf.user.username + '/attachments/' + answer
                 meta_ans[item['question_name']] = answer
+
+            elif item.get('question_type') == 'FormSubStat' and fs_proj_xf.id == item.get('form_id', 0):
+                answer = "Last submitted on " + instance.date.strftime("%d %b %Y %I:%M %P")
+                meta_ans[item['question_name']] = answer
+
+            elif item.get('question_type') == "FormQuestionAnswerStatus":
+                get_answer = instance.json.get(item.get('question').get('name'), None)
+                if get_answer:
+                    answer = "Answered"
+                else:
+                    answer = ""
+                meta_ans[item['question_name']] = answer
+
+            elif item.get('question_type') == "FormSubCountQuestion":
+                meta_ans[item['question_name']] = fs_proj_xf.project_form_instances.filter(site_id=site.id).count()
 
         SiteMetaAttrAnsHistory.objects.create(site=site, meta_attributes_ans=site.site_meta_attributes_ans, status=1)
         site.site_meta_attributes_ans = meta_ans

--- a/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
+++ b/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
@@ -54,8 +54,19 @@ def update_meta_details(fs_proj_xf, instance):
                     if logo_url:
                         site.site_featured_images[question_name] = logo_url
 
-
-            site.save()
+        # change site meta attributes answer
+        meta_ans = site.site_meta_attributes_ans
+        for item in fs_proj_xf.project.site_meta_attributes:
+            if item.get('question_type', '') == 'Form' and fs_proj_xf.id == item.get('form_id', 0):
+                if item['question']['type'] == "repeat":
+                    answer = ""
+                else:
+                    answer = instance.get(item.get('question').get('name'), '')
+                if item['question']['type'] in ['photo', 'video', 'audio'] and answer is not "":
+                    answer = 'http://app.fieldsight.org/attachment/medium?media_file=' + fs_proj_xf.xf.user.username + '/attachments/' + answer
+                meta_ans[item['question_name']] = answer
+        site.site_meta_attributes_ans = meta_ans
+        site.save()
     except:
         pass
 

--- a/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
+++ b/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
@@ -13,7 +13,7 @@ from onadata.apps.api.viewsets.xform_submission_api import XFormSubmissionApi
 from onadata.apps.eventlog.models import FieldSightLog
 from onadata.apps.fieldsight.models import Site
 from onadata.apps.fsforms.models import FieldSightXF, Stage, Schedule, SubmissionOfflineSite, FInstance, \
-    EditedSubmission
+    EditedSubmission, SiteMetaAttrAnsHistory
 from onadata.apps.fsforms.serializers.FieldSightSubmissionSerializer import FieldSightSubmissionSerializer
 from ..fieldsight_logger_tools import safe_create_instance
 from channels import Group as ChannelGroup
@@ -65,6 +65,8 @@ def update_meta_details(fs_proj_xf, instance):
                 if item['question']['type'] in ['photo', 'video', 'audio'] and answer is not "":
                     answer = 'http://app.fieldsight.org/attachment/medium?media_file=' + fs_proj_xf.xf.user.username + '/attachments/' + answer
                 meta_ans[item['question_name']] = answer
+
+        SiteMetaAttrAnsHistory.objects.create(site=site, meta_attributes_ans=site.site_meta_attributes_ans, status=1)
         site.site_meta_attributes_ans = meta_ans
         site.save()
     except:

--- a/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
+++ b/onadata/apps/fsforms/viewsets/FSXFormSubmissionApiViewset.py
@@ -100,7 +100,10 @@ class FSXFormSubmissionApi(XFormSubmissionApi):
                                                                  extra_message="project",
                                                                  content_object=instance.fieldsight_instance)
                     else:
-                        task_obj = CeleryTaskProgress.objects.create(user=request.user, description='Change site info', task_type=25, content_obj=instance)
+                        task_obj = CeleryTaskProgress.objects.create(user=self.request.user,
+                                                                     description='Change site info',
+                                                                     task_type=25,
+                                                                     content_obj=instance.fieldsight_instance)
                         if task_obj:
                             from onadata.apps.fieldsight.tasks import update_meta_details
                             update_meta_details.delay(fs_proj_xf.id, instance.id, task_obj.id)

--- a/onadata/apps/fv3/views.py
+++ b/onadata/apps/fv3/views.py
@@ -17,7 +17,7 @@ from rest_framework.authentication import BasicAuthentication, SessionAuthentica
 from rest_framework import generics, status
 from rest_framework.views import APIView
 from django.contrib.gis.geos import Point
-from onadata.apps.fieldsight.models import Project, Region, Site, Sector, SiteType, ProjectLevelTermsAndLabels, ProjectMetaAttrHistory
+from onadata.apps.fieldsight.models import Project, Region, Site, Sector, SiteType, ProjectLevelTermsAndLabels, ProjectMetaAttrHistory, SiteMetaAttrAnsHistory
 from onadata.apps.fsforms.models import FInstance, ProgressSettings
 
 from onadata.apps.fsforms.notifications import get_notifications_queryset
@@ -32,6 +32,8 @@ from onadata.apps.eventlog.models import CeleryTaskProgress
 from onadata.apps.geo.models import GeoLayer
 from onadata.apps.fv3.serializers.project_settings import ProgressSettingsSerializer
 from .role_api_permissions import ProjectRoleApiPermissions
+
+from onadata.apps.fieldsight.utils.siteMetaAttribs import get_site_meta_ans
 
 
 class ProjectSitesPagination(PageNumberPagination):
@@ -592,6 +594,12 @@ class ProjectDefineSiteMeta(APIView):
 
                 other_project.save()
         project.save()
+        sites = Site.objects.filter(project_id=project.id)
+        for site in sites:
+            SiteMetaAttrAnsHistory.objects.create(site=site, meta_attributes_ans=site.site_meta_attributes_ans, status=2)
+            metas = get_site_meta_ans(site.id)
+            site.site_meta_attributes_ans = metas
+            site.save()
 
         return Response({'message': "Successfully created", 'status': status.HTTP_201_CREATED})
 

--- a/onadata/apps/fv3/views.py
+++ b/onadata/apps/fv3/views.py
@@ -596,7 +596,7 @@ class ProjectDefineSiteMeta(APIView):
         project.save()
         task_obj = CeleryTaskProgress.objects.create(user=request.user,
                                                      description="Update site meta attributes answer and store history",
-                                                     task_type=20, content_object=project)
+                                                     task_type=24, content_object=project)
         if task_obj:
             create_site_meta_attribs_ans_history.delay(project.id, task_obj.id)
 


### PR DESCRIPTION
1. Model for site meta attributes answer history.
2. Update site meta attributes answer directly in database on change of meta attributes questions or incoming submission. 
3. Keep history of meta attributes answer on change in project meta attributes.
4. Keep history of meta attributes answer on submission.